### PR TITLE
Rename from "pstack" to "pystack"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2018, Haochuan Guo
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of pystack nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
-# pstack
+# pystack
 
-pstack is to python as jstack is to java! It's a debug tool to print python threads or greenlet stacks.
+pystack is to python as jstack is to java!
+
+It's a debug tool to print python threads or greenlet stacks.
 
 Idea stolen from [pyrasite](https://github.com/lmacken/pyrasite)
 
 ## Install
-```bash
-$ pip install pstack
+
+```
+$ pip install pystack
 ```
 
 ## Usage
 
 You may need to run it with `sudo`.
 
-```bash
+```
 $ sudo pstack <pid> [--include-greenlet]
 ```

--- a/pystack.py
+++ b/pystack.py
@@ -101,13 +101,13 @@ CONTEXT_SETTINGS = {
 @click.option('-d', '--debugger', type=click.Choice(['gdb', 'lldb']))
 @click.option('-v', '--verbose', default=False, is_flag=True,
               help="Verbosely print error and warnings")
-def stack(pid, include_greenlet, debugger, verbose):
+def main(pid, include_greenlet, debugger, verbose):
     '''Print stack of python process.
 
-    $ pstack <pid>
+    $ pystack <pid>
     '''
     return print_stack(pid, include_greenlet, debugger, verbose)
 
 
 if __name__ == '__main__':
-    stack()
+    main()

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,11 @@ setup(
     long_description=open('README.md').read(),
     author='Haochuan Guo',
     author_email='guohaochuan@gmail.com',
+    maintainer='Jiangge Zhang',
+    maintainer_email='tonyseek@gmail.com',
     py_modules=['pystack'],
     zip_safe=False,
+    license='MIT',
     url='https://github.com/wooparadog/pystack/',
     keywords=['pystack', 'pstack', 'jstack', 'gdb', 'lldb', 'greenlet'],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,16 @@
 from setuptools import setup
 
 setup(
-    name='pstack',
+    name='pystack',
     version='0.6',
     description='Tool to print python thread and greenlet stacks',
     author="Haochuan Guo",
     author_email='guohaochuan@gmail.com',
-    py_modules=['stack'],
-    url='https://github.com/wooparadog/pstack/',
+    py_modules=['pystack'],
+    url='https://github.com/wooparadog/pystack/',
     entry_points={
         'console_scripts': [
-            ['pstack = stack:stack'],
+            ['pystack = pystack:main'],
         ],
     },
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,13 @@ setup(
     name='pystack',
     version='0.6',
     description='Tool to print python thread and greenlet stacks',
-    author="Haochuan Guo",
+    long_description=open('README.md').read(),
+    author='Haochuan Guo',
     author_email='guohaochuan@gmail.com',
     py_modules=['pystack'],
+    zip_safe=False,
     url='https://github.com/wooparadog/pystack/',
+    keywords=['pystack', 'pstack', 'jstack', 'gdb', 'lldb', 'greenlet'],
     entry_points={
         'console_scripts': [
             ['pystack = pystack:main'],
@@ -17,5 +20,21 @@ setup(
     },
     install_requires=[
         'click>=5.1,<6.0',
+    ],
+    platforms=['Any'],
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'Intended Audience :: System Administrators',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: MacOS',
+        'Operating System :: POSIX',
+        'Operating System :: POSIX :: Linux',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Topic :: Software Development',
+        'Topic :: Software Development :: Debuggers',
+        'Topic :: Utilities',
     ],
 )

--- a/test_pystack.py
+++ b/test_pystack.py
@@ -7,7 +7,7 @@ from pytest import fixture, mark, param
 from distutils.spawn import find_executable
 from click.testing import CliRunner
 
-import stack as main
+from pystack import main
 
 
 skipif_non_gdb = mark.skipif(
@@ -42,7 +42,6 @@ def cli():
     param(STATEMENTS['sleep'], 'lldb', marks=skipif_non_lldb),
 ], indirect=['process'])
 def test_smoke(cli, process, debugger):
-    pid = str(process.pid)
-    result = cli.invoke(main.stack, [pid, '--debugger', debugger])
+    result = cli.invoke(main, [str(process.pid), '--debugger', debugger])
     assert result.exit_code == 0
     assert '  File "<string>", line 1, in <module>\n' in result.output

--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,4 @@ deps =
     pytest-cov
     pytest-pep8
 commands =
-    py.test --cov=stack {posargs}
+    py.test --cov=pystack {posargs}


### PR DESCRIPTION
Because "pstack" has been used by https://linux.die.net/man/1/pstack.