### PR TITLE
Fix console_scripts entry_points

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     keywords=['pystack', 'pstack', 'jstack', 'gdb', 'lldb', 'greenlet'],
     entry_points={
         'console_scripts': [
-            ['pystack = pystack:main'],
+            'pystack = pystack:main',
         ],
     },
     install_requires=[


### PR DESCRIPTION
Elements of the console_scripts list should be strings, not lists of strings.

Docs: https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation

This breaks some automated processing of the package metadata.