### PR TITLE
Fix compatibility with Python 3.12

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,9 +1,6 @@
 FROM quay.io/fedora/fedora:37
 
 RUN dnf install -y --setopt=install_weak_deps=False \
-        python2.7 \
-        python3.6 \
-        python3.7 \
         python3.8 \
         python3.9 \
         python3.10 \

--- a/Containerfile
+++ b/Containerfile
@@ -7,6 +7,7 @@ RUN dnf install -y --setopt=install_weak_deps=False \
         python3.11 \
         python3.12 \
         tox \
+        python-coverage \
         gdb \
         lldb \
         which \

--- a/README.md
+++ b/README.md
@@ -30,3 +30,11 @@ Using PyPy may work in client side (the debugger) but it is untested. Do not
 attempt to attach a PyPy process as destination. It may lead to unexpected and
 undefined behavior, because the pystack debugger uses gdb/lldb to invoke the
 CPython ABI.
+
+## Development
+
+Run testing on a container environment:
+
+    $ podman machine start
+    $ ./test.sh
+    $ ./test.sh coverage html

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![PyPI](https://img.shields.io/pypi/v/pystack-debugger.svg)](https://pypi.org/project/pystack-debugger/)
 
-# pystack
+# pystack-debugger
 
-The pystack is to python as jstack is to java.
+The pystack-debugger is to python as jstack is to java.
 
 It's a debug tool to print python threads or greenlet stacks.
 
@@ -23,9 +23,10 @@ You may need to run it with `sudo`.
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pystack-debugger.svg)](https://pypi.org/project/pystack-debugger/)
 [![PyPI - Implementation](https://img.shields.io/pypi/implementation/pystack-debugger.svg)](https://pypi.org/project/pystack-debugger/)
 
-The pystack is compatible with CPython 2.7+ and CPython 3.6+ in both client
-(the debugger) and server (the destination process).
+The pystack is compatible with CPython 3.8+ in both client side (the debugger)
+and server side (the destination process).
 
-Using PyPy may work in client (the debugger) but it is untested. Do not attempt
-to attach a PyPI process as destination since the pystack debugger uses gdb/lldb
-to invoke the CPython ABI.
+Using PyPy may work in client side (the debugger) but it is untested. Do not
+attempt to attach a PyPy process as destination. It may lead to unexpected and
+undefined behavior, because the pystack debugger uses gdb/lldb to invoke the
+CPython ABI.

--- a/pystack.py
+++ b/pystack.py
@@ -10,7 +10,7 @@ import platform
 import functools
 import codecs
 import locale
-import distutils.spawn
+import shutil
 
 import click
 
@@ -65,7 +65,7 @@ def make_lldb_args(pid, command):
 
 
 def find_debugger(name):
-    debugger = distutils.spawn.find_executable(name)
+    debugger = shutil.which(name)
     if not debugger:
         raise DebuggerNotFound(
             'Could not find "%s" in your PATH environment variable' % name)

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,6 @@ setup(
     install_requires=[
         'click',
     ],
-    setup_requires=[
-        'setuptools>=38.6.0',
-    ],
     platforms=['linux', 'darwin'],
     classifiers=[
         'Development Status :: 3 - Alpha',
@@ -37,15 +34,12 @@ setup(
         'Operating System :: MacOS',
         'Operating System :: POSIX',
         'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Software Development',
         'Topic :: Software Development :: Debuggers',

--- a/test_pystack.py
+++ b/test_pystack.py
@@ -4,9 +4,9 @@ import sys
 import subprocess
 import platform
 import time
+import shutil
 
 from pytest import fixture, mark, param, raises
-from distutils.spawn import find_executable
 from click.testing import CliRunner
 
 from pystack import (
@@ -14,9 +14,9 @@ from pystack import (
 
 
 skipif_non_gdb = mark.skipif(
-    not find_executable('gdb'), reason='gdb not found')
+    shutil.which('gdb') is None, reason='gdb not found')
 skipif_non_lldb = mark.skipif(
-    not find_executable('lldb'), reason='lldb not found')
+    shutil.which('lldb') is None, reason='lldb not found')
 skipif_darwin = mark.skipif(
     platform.system().lower() == 'darwin', reason='gdb on darwin is unstable')
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,py38,py39,py310,py311
+envlist = py38,py39,py310,py311,py312
 
 [testenv]
 changedir = {toxinidir}


### PR DESCRIPTION
- `distutils` has been removed since Python 3.12
- Python 2.7 to 3.7 is end-of-life (https://endoflife.date/python)